### PR TITLE
Enforce authentication for products API

### DIFF
--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-// import { auth } from '@/lib/auth-utils'; // TODO: Fix auth issues
+import { auth } from '@/lib/auth-utils';
 import { db } from '@/db';
 import { products, productVariants } from '@/db/schema';
 import { getProductsQuerySchema, type ProductsListResponse, type ProductListItem } from '@/lib/validation/products';
@@ -8,12 +8,11 @@ import { eq, and, or, ilike, sql, desc, asc, gt, lt, inArray } from 'drizzle-orm
 
 export async function GET(request: NextRequest) {
   try {
-    // TODO: Re-enable authentication once auth is properly configured
     // Check authentication
-    // const session = await auth();
-    // if (!session?.user) {
-    //   return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    // }
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
 
     // Parse and validate query parameters
     const searchParams = request.nextUrl.searchParams;

--- a/tests/api.products.integration.test.ts
+++ b/tests/api.products.integration.test.ts
@@ -10,6 +10,19 @@ import {
 } from '@/db/schema';
 import { eq } from 'drizzle-orm';
 
+// Unauthorized access tests
+describe('Products API Authentication', () => {
+  it('should reject unauthorized product requests', async () => {
+    const response = await fetch('http://localhost:3000/api/products');
+    expect(response.status).toBe(401);
+  });
+
+  it('should reject unauthorized filter requests', async () => {
+    const response = await fetch('http://localhost:3000/api/products/filters');
+    expect(response.status).toBe(401);
+  });
+});
+
 // Mock data for testing
 const testBrand = {
   id: 'test-brand-id',


### PR DESCRIPTION
## Summary
- require authenticated session in products API route
- add integration tests checking unauthorized access is denied

## Testing
- `npm test` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fd6612188333ac7c0fdd165e3464