### PR TITLE
feat: support repeated product filter params

### DIFF
--- a/tests/api.products.params.test.ts
+++ b/tests/api.products.params.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { getProductsQuerySchema } from '@/lib/validation/products';
+
+describe('Products API query parsing', () => {
+  const id1 = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+  const id2 = '9c5d1d62-1f0e-4e6d-8a6b-6d2f5a6a4b2d';
+
+  it('parses repeated query params into arrays', () => {
+    const params = new URLSearchParams();
+    params.append('brandIds', id1);
+    params.append('brandIds', id2);
+    params.append('categoryIds', id1);
+
+    const requestParams = {
+      cursor: params.get('cursor') || undefined,
+      limit: params.get('limit') || undefined,
+      page: params.get('page') || undefined,
+      search: params.get('search') || undefined,
+      sortBy: params.get('sortBy') || undefined,
+      sortOrder: params.get('sortOrder') || undefined,
+      status: params.get('status') || undefined,
+      type: params.get('type') || undefined,
+      brandIds: params.getAll('brandIds').filter(Boolean),
+      categoryIds: params.getAll('categoryIds').filter(Boolean),
+      shopIds: params.getAll('shopIds').filter(Boolean),
+    };
+
+    const validated = getProductsQuerySchema.parse(requestParams);
+    expect(validated.brandIds).toEqual([id1, id2]);
+    expect(validated.categoryIds).toEqual([id1]);
+  });
+
+  it('rejects comma separated values in single param', () => {
+    const params = new URLSearchParams();
+    params.set('brandIds', `${id1},${id2}`);
+
+    const requestParams = {
+      cursor: params.get('cursor') || undefined,
+      limit: params.get('limit') || undefined,
+      page: params.get('page') || undefined,
+      search: params.get('search') || undefined,
+      sortBy: params.get('sortBy') || undefined,
+      sortOrder: params.get('sortOrder') || undefined,
+      status: params.get('status') || undefined,
+      type: params.get('type') || undefined,
+      brandIds: params.getAll('brandIds').filter(Boolean),
+      categoryIds: params.getAll('categoryIds').filter(Boolean),
+      shopIds: params.getAll('shopIds').filter(Boolean),
+    };
+
+    expect(() => getProductsQuerySchema.parse(requestParams)).toThrow();
+  });
+});
+

--- a/tests/useProducts.buildApiUrl.test.ts
+++ b/tests/useProducts.buildApiUrl.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { buildApiUrl } from '@/app/products/hooks/useProducts';
+import type { ProcessedSearchParams } from '@/app/products/params';
+
+describe('buildApiUrl', () => {
+  it('appends multiple values for array parameters', () => {
+    const params: ProcessedSearchParams = {
+      search: undefined,
+      status: undefined,
+      type: undefined,
+      brandIds: ['11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222'],
+      categoryIds: ['33333333-3333-3333-3333-333333333333'],
+      shopIds: ['44444444-4444-4444-4444-444444444444', '55555555-5555-5555-5555-555555555555'],
+      sortBy: 'name',
+      sortOrder: 'asc',
+      limit: 10,
+      page: 1,
+      cursor: undefined,
+      viewMode: 'grid',
+      paginationMode: 'pages',
+    };
+
+    const url = buildApiUrl(params);
+    const searchParams = new URL(url, 'http://localhost').searchParams;
+
+    expect(searchParams.getAll('brandIds')).toEqual(params.brandIds);
+    expect(searchParams.getAll('categoryIds')).toEqual(params.categoryIds);
+    expect(searchParams.getAll('shopIds')).toEqual(params.shopIds);
+  });
+});
+


### PR DESCRIPTION
## Summary
- build product URLs with repeated brand/category/shop IDs
- ensure stable cache keys by reusing URL builder
- add tests for client URL building and server param parsing

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:5432)*
- `npm run lint` *(fails: 97 problems, 34 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fee14afc8333a7ef1f2fcf152e95