### PR TITLE
Enable site-wide auth with profile page

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,11 @@
+import { withAuth } from 'next-auth/middleware';
+
+export default withAuth({
+  pages: {
+    signIn: '/login',
+  },
+});
+
+export const config = {
+  matcher: ['/((?!login|api/auth|_next/static|_next/image|favicon.ico).*)'],
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { MainLayout } from '@/components/layout/MainLayout';
 import { SettingsProvider } from '@/contexts/SettingsContext';
+import { SessionProvider } from '@/components/providers/SessionProvider';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -16,9 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="antialiased" suppressHydrationWarning={true}>
-        <SettingsProvider>
-          <MainLayout>{children}</MainLayout>
-        </SettingsProvider>
+        <SessionProvider>
+          <SettingsProvider>
+            <MainLayout>{children}</MainLayout>
+          </SettingsProvider>
+        </SessionProvider>
       </body>
     </html>
   );

--- a/src/app/profile/ProfileClient.tsx
+++ b/src/app/profile/ProfileClient.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { signOut } from 'next-auth/react';
+
+type ProfileClientProps = {
+  user: {
+    email?: string | null;
+  };
+};
+
+export default function ProfileClient({ user }: ProfileClientProps) {
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 py-6">
+      <h1 className="text-2xl font-semibold text-gray-900 mb-6">Profile</h1>
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-sm font-medium text-gray-500">Email</h2>
+          <p className="mt-1 text-sm text-gray-900">{user.email}</p>
+        </div>
+        <div>
+          <button
+            onClick={() => signOut({ callbackUrl: '/login' })}
+            className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            Log out
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,15 @@
+import { auth } from '@/lib/auth-utils';
+import { redirect } from 'next/navigation';
+import ProfileClient from './ProfileClient';
+
+export default async function Page() {
+  const session = await auth();
+  if (!session?.user) {
+    redirect('/login');
+  }
+  return <ProfileClient user={session.user} />;
+}
+
+export const metadata = {
+  title: 'Profile - WooCommerce Product Manager',
+};

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -16,8 +16,10 @@ import {
   Globe,
   Images,
   Camera,
+  User,
 } from 'lucide-react';
 import { useState } from 'react';
+import { useSession, signOut } from 'next-auth/react';
 
 const navigation = [
   { name: 'Dashboard', href: '/', icon: Home },
@@ -39,6 +41,7 @@ interface MainLayoutProps {
 export function MainLayout({ children }: MainLayoutProps) {
   const pathname = usePathname();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const { data: session } = useSession();
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -88,9 +91,19 @@ export function MainLayout({ children }: MainLayoutProps) {
                 </h1>
               </div>
               <div className="ml-4 flex items-center md:ml-6">
-                <div className="text-sm text-gray-500">
-                  Connected to: 192.168.0.180
-                </div>
+                {session?.user && (
+                  <div className="flex items-center space-x-4">
+                    <span className="text-sm text-gray-700">
+                      {session.user.email}
+                    </span>
+                    <button
+                      onClick={() => signOut({ callbackUrl: '/login' })}
+                      className="text-sm text-gray-500 hover:text-gray-700"
+                    >
+                      Log out
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
           </div>
@@ -105,6 +118,7 @@ export function MainLayout({ children }: MainLayoutProps) {
 
 function Sidebar() {
   const pathname = usePathname();
+  const { data: session } = useSession();
 
   return (
     <div className="flex flex-1 flex-col min-h-0 bg-white border-r border-gray-200">
@@ -143,17 +157,16 @@ function Sidebar() {
           })}
         </nav>
 
-        {/* Connection status */}
-        <div className="flex-shrink-0 px-4 py-4 border-t border-gray-200">
-          <div className="flex items-center">
-            <div className="h-2 w-2 bg-green-400 rounded-full"></div>
-            <span className="ml-2 text-xs text-gray-500">
-              Database Connected
+        <div className="flex-shrink-0 border-t border-gray-200">
+          <Link
+            href="/profile"
+            className="flex items-center px-4 py-4 hover:bg-gray-50"
+          >
+            <User className="h-5 w-5 text-gray-400" />
+            <span className="ml-3 text-sm font-medium text-gray-700">
+              {session?.user?.email ?? 'Profile'}
             </span>
-          </div>
-          <div className="mt-1 text-xs text-gray-400">
-            PostgreSQL: 192.168.0.180:5432
-          </div>
+          </Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- protect all app routes using NextAuth middleware
- wrap app with SessionProvider and add user profile page
- redesign layout to show profile link and logout

## Testing
- `npx vitest run` *(fails: connect ECONNREFUSED ::1:5432)*
- `npm run lint` *(fails: 5 errors, 64 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b3478cb82c83339d902d1e7dca416a